### PR TITLE
chore(kuma-cp): use appProtocol

### DIFF
--- a/demo.yaml
+++ b/demo.yaml
@@ -79,12 +79,10 @@ kind: Service
 metadata:
   name: demo-app
   namespace: kuma-demo
-  annotations:
-    5000.service.kuma.io/protocol: http
-    ingress.kubernetes.io/service-upstream: "true"
 spec:
   selector:
     app: demo-app
   ports:
   - protocol: TCP
+    appProtocol: http
     port: 5000


### PR DESCRIPTION
Use appProtocol
Remove service-upstream since Kuma automatically annotates service with it, we should not give a hint for users that they need to do it by hand