### PR TITLE
chore(*): graceful shutdown

### DIFF
--- a/demo.yaml
+++ b/demo.yaml
@@ -27,6 +27,9 @@ spec:
             - name: tcp
               containerPort: 6379
           lifecycle:
+            preStop: # delay shutdown to support graceful mesh leave
+              exec:
+                command: ["/bin/sleep", "30"]
             postStart:
               exec:
                 command: ["/usr/local/bin/redis-cli", "set", "zone", "local"]


### PR DESCRIPTION
demo app ignores sigterm so it's graceful, but redis quits immediately.