### PR TITLE
Remove kuma.io/service from MeshGatewayInstance

### DIFF
--- a/gateway.yaml
+++ b/gateway.yaml
@@ -42,5 +42,3 @@ metadata:
 spec:
   replicas: 1
   serviceType: LoadBalancer
-  tags:
-    kuma.io/service: demo-app_gateway


### PR DESCRIPTION
It's deprecated

<Explain your change!>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
