### PR TITLE
chore(gateway): replace MeshGatewayRoute with MeshHTTPRoute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/gateway.yaml
+++ b/gateway.yaml
@@ -14,25 +14,26 @@ spec:
       kuma.io/service: demo-app-gateway_kuma-demo_svc
 ---
 apiVersion: kuma.io/v1alpha1
-kind: MeshGatewayRoute
-mesh: default
+kind: MeshHTTPRoute
 metadata:
   name: demo-app
+  namespace: kuma-system
 spec:
-  conf:
-   http:
+  targetRef:
+    kind: MeshGateway
+    name: demo-app
+  to:
+  - targetRef:
+      kind: Mesh
     rules:
-    - matches:
+    - default:
+        backendRefs:
+        - kind: MeshService
+          name: demo-app_kuma-demo_svc_5000
+      matches:
       - path:
-          match: PREFIX
+          type: PathPrefix
           value: /
-      backends:
-      - destination:
-          kuma.io/service: demo-app_kuma-demo_svc_5000
-        weight: 1
-  selectors:
-  - match:
-      kuma.io/service: demo-app_gateway
 ---
 apiVersion: kuma.io/v1alpha1
 kind: MeshGatewayInstance


### PR DESCRIPTION
Usage of MeshHTTPRoute is suggested now over MeshGatewayRoute

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
