### PR TITLE
added flag to set ip_version in redis client

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ We can configure the following environment variables when running `demo-app`:
 * `REDIS_HOST`: Determines the hostname to use when connecting to Redis. Default is `127.0.0.1`.
 * `REDIS_PORT`: Determines the port to use when connecting to Redis. Default is `6379`.
 * `APP_VERSION`: Lets you change the version number displayed in the main page of `demo-app`. Default is `1.0`.
-* `APP_COLOR`: Lets you change background color of the `demo-app` main page. Default is `#efefef`.
+* `APP_COLOR`: Lets you change background color of the `demo-app` main page. Default is `#FAFAFA`.
+* `IP_VERSION`: Lets you change the IP family version to use when connecting to Redis. Default is `4` for IPv4, with the option to set as `6` for IPv6.
 
 The `APP_VERSION` and `APP_COLOR` environment variables are handy when we want to create different versions of `demo-app` and get immediate visual feedback when routing across them.
 

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -174,7 +174,6 @@
 
     #header {
       padding: 50px;
-      background-color: #efefef;
     }
 
     #counter {
@@ -443,7 +442,7 @@
 
     <div class="columns">
       <div class="info">
-        <h1 class="type-xxxl">Kuma Counter Demo <span id="version"></span></h1>
+        <h1 class="type-xxxl" id="header">Kuma Counter Demo <span id="version"></span></h1>
         <p class="type-xl">
           Welcome to a simple demo application to demonstrate how the Kuma service mesh works. This application allows us
           to increment a counter, and it is made of two different services:

--- a/app/server.js
+++ b/app/server.js
@@ -10,7 +10,7 @@ const PORT = 5000;
 const app = express();
 
 const version = process.env.APP_VERSION || "1.0";
-const color = process.env.APP_COLOR || "#efefef";
+const color = process.env.APP_COLOR || "#FAFAFA";
 
 function getClient() {
   const host = process.env.REDIS_HOST || "127.0.0.1";

--- a/app/server.js
+++ b/app/server.js
@@ -15,11 +15,12 @@ const color = process.env.APP_COLOR || "#efefef";
 function getClient() {
   const host = process.env.REDIS_HOST || "127.0.0.1";
   const port = parseInt(process.env.REDIS_PORT) || 6379;
+  const ip_version = parseInt(process.env.IP_VERSION) || 4;
   console.log("Connecting to Redis at %s:%d", host, port);
   const client = new Redis({
     port: port,
     host: host,
-    family: 4,
+    family: ip_version,
     autoResendUnfulfilledCommands: false,
     autoResubscribe: false,
     enableOfflineQueue: true,


### PR DESCRIPTION
Adding the optional flag to set the redis client IP version family via environment variable. This change is intended to enable the use of the demo app in IPv6-only environments.
