### PR TITLE
feat(docker): add debian-slim images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,10 +54,22 @@ dockers:
     build_flag_templates:
       - "--label=org.opencontainers.image.source=https://github.com/kumahq/kuma-counter-demo"
       - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+  - id: demo-app-debian-slim
+    image_templates:
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-debian-slim
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-debian-slim
+      - ghcr.io/kumahq/kuma-counter-demo:debian-slim
+    dockerfile: ./app/Dockerfile
+    build_flag_templates:
+      - "--label=org.opencontainers.image.source=https://github.com/kumahq/kuma-counter-demo"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=BASE_IMAGE=debian:12.8-slim"
 
 release:
   draft: true

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,5 @@
-FROM scratch
+ARG BASE_IMAGE=scratch
+FROM $BASE_IMAGE
 
 ENTRYPOINT ["/kuma-counter-demo"]
 ADD kuma-counter-demo /


### PR DESCRIPTION
Added debian-slim images to include the application binary, making it easier to install required tooling. This is useful for guides like setting up a transparent proxy in Docker, allowing the use of demo images without extra steps to clone the repo, build the binary etc. Slim images provide a lightweight alternative.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
