### PR TITLE
chore(build/release): add multi-arch support for counter demo images v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,6 +46,7 @@ changelog:
 dockers:
   - id: demo-app-amd64
     use: buildx
+    goarch: amd64
     image_templates:
       - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-amd64
       - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-amd64
@@ -78,6 +79,7 @@ dockers:
 
   - id: demo-app-debian-slim-amd64
     use: buildx
+    goarch: amd64
     image_templates:
       - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-debian-slim-amd64
       - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-debian-slim-amd64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,31 +44,97 @@ changelog:
       - '^test:'
 
 dockers:
-  - id: demo-app
+  - id: demo-app-amd64
+    use: buildx
     image_templates:
-      - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}
-      - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}
-      - ghcr.io/kumahq/kuma-counter-demo:latest
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-amd64
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-amd64
+      - ghcr.io/kumahq/kuma-counter-demo:latest-amd64
     dockerfile: ./app/Dockerfile
     build_flag_templates:
+      - "--pull"
       - "--label=org.opencontainers.image.source=https://github.com/kumahq/kuma-counter-demo"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-  - id: demo-app-debian-slim
+      - "--platform=linux/amd64"
+  - id: demo-app-arm64
+    use: buildx
+    goarch: arm64
     image_templates:
-      - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-debian-slim
-      - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-debian-slim
-      - ghcr.io/kumahq/kuma-counter-demo:debian-slim
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-arm64
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-arm64
+      - ghcr.io/kumahq/kuma-counter-demo:latest-arm64
     dockerfile: ./app/Dockerfile
     build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.source=https://github.com/kumahq/kuma-counter-demo"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--platform=linux/arm64"
+
+  - id: demo-app-debian-slim-amd64
+    use: buildx
+    image_templates:
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-debian-slim-amd64
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-debian-slim-amd64
+      - ghcr.io/kumahq/kuma-counter-demo:debian-slim-amd64
+    dockerfile: ./app/Dockerfile
+    build_flag_templates:
+      - "--pull"
       - "--label=org.opencontainers.image.source=https://github.com/kumahq/kuma-counter-demo"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--build-arg=BASE_IMAGE=debian:12.8-slim"
+      - "--platform=linux/amd64"
+  - id: demo-app-debian-slim-arm64
+    use: buildx
+    goarch: arm64
+    image_templates:
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-debian-slim-arm64
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-debian-slim-arm64
+      - ghcr.io/kumahq/kuma-counter-demo:debian-slim-arm64
+    dockerfile: ./app/Dockerfile
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.source=https://github.com/kumahq/kuma-counter-demo"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=BASE_IMAGE=debian:12.8-slim"
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}"
+    image_templates:
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-amd64
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-arm64
+  - name_template: "ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}"
+    image_templates:
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-amd64
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-arm64
+  - name_template: "ghcr.io/kumahq/kuma-counter-demo:latest"
+    image_templates:
+      - ghcr.io/kumahq/kuma-counter-demo:latest-amd64
+      - ghcr.io/kumahq/kuma-counter-demo:latest-arm64
+  - name_template: "ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-debian-slim"
+    image_templates:
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-debian-slim-amd64
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Tag }}-debian-slim-arm64
+  - name_template: "ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-debian-slim"
+    image_templates:
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-debian-slim-amd64
+      - ghcr.io/kumahq/kuma-counter-demo:{{ .Major }}-debian-slim-arm64
+  - name_template: "ghcr.io/kumahq/kuma-counter-demo:debian-slim"
+    image_templates:
+      - ghcr.io/kumahq/kuma-counter-demo:debian-slim-amd64
+      - ghcr.io/kumahq/kuma-counter-demo:debian-slim-arm64
 
 release:
   draft: true

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ clean:
 .PHONY: all
 all: check build test run
 
+.PHONY: release
+release:
+	$(GORELEASER) release --clean
+
 .PHONY: check
 check: tidy fmt lint
 


### PR DESCRIPTION
- Updated .goreleaser.yaml to build and publish for amd64 and arm64
- Configured multi-arch Docker manifests for both normal and debian-slim images
- Added a new `release` target in the Makefile for easier build/publish flow

---

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
