### PR TITLE
chore(docs): remove missing functionality from the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,5 @@ To add delay to response you need to set header `x-set-response-delay-ms`. Examp
 curl localhost:5050/api/counter -XPOST -H "x-set-response-delay-ms: 5000"
 ```
 
-### Enforcing response status code
-
-To enforce response status code you need to set header `x-set-response-status-code`. Example:
-
-```shell
-curl localhost:5050/api/counter -XPOST -H "x-set-response-status-code: 503"
-```
-
 [kuma-url]: https://kuma.io/
 [kuma-logo]: https://kuma-public-assets.s3.amazonaws.com/kuma-logo-v2.png


### PR DESCRIPTION
Setting response code is currently not possible, so it shouldn't be described in the README.md

---

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
