### PR TITLE
Revert "chore(docs): remove missing functionality from the README.md …(#77)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,13 @@ To add delay to response you need to set header `x-set-response-delay-ms`. Examp
 curl localhost:5050/api/counter -XPOST -H "x-set-response-delay-ms: 5000"
 ```
 
+### Enforcing response status code
+
+To enforce response status code you need to set header `x-set-response-status-code`. Example:
+
+```shell
+curl localhost:5050/api/counter -XPOST -H "x-set-response-status-code: 503"
+```
+
 [kuma-url]: https://kuma.io/
 [kuma-logo]: https://kuma-public-assets.s3.amazonaws.com/kuma-logo-v2.png


### PR DESCRIPTION
This reverts commit 1f33a2d8720d4654813396c10d027de37675a523.

It's not that easy and this header works but with only when calling `kv` api

---

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
