### PR TITLE
ci(renovate): fix broken config by switching to shared security preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,21 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    ":configMigration",
+    "customManagers:makefileVersions",
     "Kong/public-shared-renovate:backend",
-    "Kong/public-shared-renovate:makefile",
-    "kumahq/kuma//.renovate/mise",
-    "kumahq/kuma//.renovate/security"
+    "Kong/public-shared-renovate:security-extended(area/security,team:kuma-security-managers)",
+    "kumahq/kuma//.renovate/mise"
   ],
-  "baseBranchPatterns": [
-    "main"
-  ],
+  "baseBranchPatterns": ["main"],
   "kubernetes": {
-    "managerFilePatterns": [
-      "/k8s/.+\\.ya?ml$/",
-      "/^kustomize\\/.+\\.ya?ml$/"
-    ],
-    "ignorePaths": [
-      "/\\/kustomization.ya?ml$/"
-    ]
+    "managerFilePatterns": ["/k8s/.+\\.ya?ml$/", "/^kustomize\\/.+\\.ya?ml$/"],
+    "ignorePaths": ["/\\/kustomization.ya?ml$/"]
   }
 }


### PR DESCRIPTION
## Motivation

The Renovate configuration in this repository was broken because it still referenced the old `kumahq/kuma//.renovate/security` preset. That preset was removed and moved to `Kong/public-shared-renovate`. As a result, Renovate could not load the configuration and failed to run, as reported in https://github.com/kumahq/kuma-counter-demo/issues/116. To fix this and align with current best practices, the configuration has been updated to use the shared security preset and to clean up outdated parts.

## Implementation information

### Updated presets

- Removed reference to `kumahq/kuma//.renovate/security`  
- Added `Kong/public-shared-renovate:security-extended(area/security,team:kuma-security-managers)`  
- Replaced deprecated `makefile` preset with `customManagers:makefileVersions`  
- Added `:configMigration` to ensure compatibility with future Renovate versions  

### Formatting cleanup

- Collapsed short arrays (`baseBranchPatterns`, `managerFilePatterns`, and `ignorePaths`) into single-line form for consistency  

## Result

- Renovate configuration loads successfully again  
- Security updates are handled through the shared security preset  
- Config is simplified and aligned with current Renovate best practices  

## Supporting documentation

Closes https://github.com/kumahq/kuma-counter-demo/issues/116