### PR TITLE
ci(renovate): fix broken config by removing deleted mise preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,7 @@
     ":configMigration",
     "customManagers:makefileVersions",
     "Kong/public-shared-renovate:backend",
-    "Kong/public-shared-renovate:security-extended(area/security,team:kuma-security-managers)",
-    "kumahq/kuma//.renovate/mise"
+    "Kong/public-shared-renovate:security-extended(area/security,team:kuma-security-managers)"
   ],
   "baseBranchPatterns": ["main"],
   "kubernetes": {


### PR DESCRIPTION
This preset was removed upstream

---

Fixes https://github.com/kumahq/kuma-counter-demo/issues/118

---

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
