### PR TITLE
fix(app): mermaid rendering

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <title>Kuma Demo</title>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
@@ -299,7 +300,11 @@
         </div>
     </div>
 </div>
-<script type="text/javascript">
+<script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+
+    mermaid.initialize({ startOnLoad: false });
+
     let running = false;
     const $status = $("#status");
     const $zone = $("#zone");
@@ -411,6 +416,8 @@
         $content.removeClass("hide");
         $status.addClass("error");
         $status.text("core error:" + error);
+    }).finally(() => {
+        mermaid.run();
     });
     $autoincrement.click(() => {
         if ($autoincrement.is(":checked")) {
@@ -443,9 +450,6 @@
         });
         running = false;
     });
-</script>
-<script type="module">
-    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
 </script>
 </body>
 </html>


### PR DESCRIPTION
Defers the rendering of graphs in `.mermaid` elements until they are displayed. This ensures that the graphs are rendered properly with the correct sizes.

I was able to reliably reproduce the issue by delaying the resolving of the promises that flip the `hide` class on the `#loading` and `#content` elements. The `.mermaid` graph element is part of the `#content` element and initially this element is hidden. Depending on the load times the `.mermaid` element may still be hidden which I assume caused the issues of the rendering. The fix is to defer the initial default rendering via `mermaid.initialize({ startOnLoad: false })` and manually trigger a rendering via `mermaid.run()` once the `#content` is not hidden anymore, which is the case once the promises are resolved.

---

Additionally I've added a [doctype](https://developer.mozilla.org/en-US/docs/Glossary/Doctype) and [html language](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/lang) to the `index.html`.

Closes https://github.com/kumahq/kuma-counter-demo/issues/109