### PR TITLE
fix(app): undefined interval

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -306,6 +306,7 @@
     mermaid.initialize({ startOnLoad: false });
 
     let running = false;
+    let interval;
     const $status = $("#status");
     const $zone = $("#zone");
     const $counter = $("#counter");


### PR DESCRIPTION
When clicking the checkbox to auto-increment it throws an error that `interval` is not defined

https://github.com/kumahq/kuma-counter-demo/blob/main/app/public/index.html#L426

```js
interval = setInterval(increment, 100);
```

`interval` needs to be set before and kept mutable (`let` vs `const`) so it can be cleared and set again.